### PR TITLE
Fixed deletion bug when swiping through SwipeCellKit

### DIFF
--- a/WoWilvlChecker/Views/ViewController.swift
+++ b/WoWilvlChecker/Views/ViewController.swift
@@ -479,7 +479,7 @@ extension ViewController: UITableViewDataSource, UITableViewDelegate, SwipeTable
     
     func tableView(_ tableView: UITableView, editActionsOptionsForRowAt indexPath: IndexPath, for orientation: SwipeActionsOrientation) -> SwipeOptions {
         var options = SwipeOptions()
-        options.expansionStyle = .destructive
+        options.expansionStyle = .destructive(automaticallyDelete: false)
         return options
     }
     


### PR DESCRIPTION
The problem is that .destructive calls the row deletion code, which you don't want. The problem is with the SwipeCellKit library. 

"The built-in .destructive, and .destructiveAfterFill expansion styles are configured to automatically perform row deletion when the action handler is invoked (automatic fulfillment). Your deletion behavior may require coordination with other row animations (eg. inside beginUpdates and endUpdates). In this case, you can easily create a custom SwipeExpansionStyle which requires manual fulfillment to trigger deletion:"
